### PR TITLE
Add undocumented `rate_details` field to typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,5 @@
     "lint": "eslint --max-warnings 0 --config=eslint.config.js"
   },
   "types": "dist/index.d.ts",
-  "version": "1.5.3"
+  "version": "1.5.4"
 }

--- a/src/v2/types/models/Rate.ts
+++ b/src/v2/types/models/Rate.ts
@@ -14,6 +14,15 @@ export interface MonetaryValue {
   amount: number;
 }
 
+interface RateDetail {
+  rate_detail_type: string;
+  carrier_description: string;
+  carrier_billing_code: string;
+  carrier_memo: string | null;
+  amount: MonetaryValue;
+  billing_source: string;
+}
+
 export interface Rate {
   /**
    * A string that uniquely identifies a ShipStation resource, such as a carrier, label, shipment, etc. [1-25]
@@ -40,6 +49,8 @@ export interface Rate {
   other_amount: MonetaryValue;
   /** A monetary value, such as the price of a shipping label, the insured value of a package, or an account balance. */
   requested_comparison_amount: MonetaryValue;
+  /** TODO: This field is not documented in the API docs but appears in the response */
+  rate_details: Array<RateDetail>;
   /** A monetary value, such as the price of a shipping label, the insured value of a package, or an account balance. */
   tax_amount: MonetaryValue;
   /**


### PR DESCRIPTION
The rate response object contains an undocumented `rate_details` field. This PR adds typings for it. Here is an example of how it looks in the API:
```json
"rate_details": [
  {
    "rate_detail_type": "location_fee",
    "carrier_description": "Residential Address",
    "carrier_billing_code": "270",
    "carrier_memo": null,
    "amount": {
      "currency": "usd",
      "amount": 6.55
    },
    "billing_source": "Carrier"
  },
  {
    "rate_detail_type": "shipping",
    "carrier_description": "Shipping",
    "carrier_billing_code": "BaseServiceCharge",
    "carrier_memo": null,
    "amount": {
      "currency": "usd",
      "amount": 128.69
    },
    "billing_source": "Carrier"
  },
  {
    "rate_detail_type": "fuel_charge",
    "carrier_description": "Fuel Surcharge",
    "carrier_billing_code": "375",
    "carrier_memo": null,
    "amount": {
      "currency": "usd",
      "amount": 22.99
    },
    "billing_source": "Carrier"
  }
]
```